### PR TITLE
[Feat/#36] 홈 (이번 달) UI 구현 및 스크롤 이슈 해결

### DIFF
--- a/FootprintIOS/FootprintIOS/Sources/Extension/Rx+Ext.swift
+++ b/FootprintIOS/FootprintIOS/Sources/Extension/Rx+Ext.swift
@@ -21,17 +21,3 @@ public extension Reactive where Base: UIViewController {
         return ControlEvent(events: source)
     }
 }
-
-
-public extension Reactive where Base: UIScrollView {
-    var pageSet: ControlEvent<Int> {
-        let event = base.rx.didScroll
-            .withLatestFrom(base.rx.contentOffset)
-            .map { offset -> Int in
-                let screenWidth = UIScreen.main.bounds.width
-                let page = round(offset.x/screenWidth)
-                return Int(page)
-            }
-        return ControlEvent(events: event)
-    }
-}

--- a/FootprintIOS/FootprintIOS/Sources/Extension/Rx+Ext.swift
+++ b/FootprintIOS/FootprintIOS/Sources/Extension/Rx+Ext.swift
@@ -21,3 +21,17 @@ public extension Reactive where Base: UIViewController {
         return ControlEvent(events: source)
     }
 }
+
+
+public extension Reactive where Base: UIScrollView {
+    var pageSet: ControlEvent<Int> {
+        let event = base.rx.didScroll
+            .withLatestFrom(base.rx.contentOffset)
+            .map { offset -> Int in
+                let screenWidth = UIScreen.main.bounds.width
+                let page = round(offset.x/screenWidth)
+                return Int(page)
+            }
+        return ControlEvent(events: event)
+    }
+}

--- a/FootprintIOS/FootprintIOS/Sources/Extension/UIStackView+.swift
+++ b/FootprintIOS/FootprintIOS/Sources/Extension/UIStackView+.swift
@@ -1,0 +1,17 @@
+//
+//  UIStackView+.swift
+//  Footprint-iOS
+//
+//  Created by 김영인 on 2022/10/25.
+//  Copyright © 2022 Footprint-iOS. All rights reserved.
+//
+
+import UIKit
+
+extension UIStackView {
+     func addArrangedSubviews(_ views: UIView...) {
+         for view in views {
+             self.addArrangedSubview(view)
+         }
+     }
+}

--- a/FootprintIOS/FootprintIOS/Sources/View/Home/Cell/MonthCollectionViewCell.swift
+++ b/FootprintIOS/FootprintIOS/Sources/View/Home/Cell/MonthCollectionViewCell.swift
@@ -1,0 +1,35 @@
+//
+//  MonthCollectionViewCell.swift
+//  Footprint-iOSTests
+//
+//  Created by 김영인 on 2022/11/04.
+//  Copyright © 2022 Footprint-iOS. All rights reserved.
+//
+
+import UIKit
+
+import ReactorKit
+
+class MonthCollectionViewCell: BaseCollectionViewCell, View {
+    
+    // MARK: - Properties
+    
+    typealias Reactor = MonthCollectionViewCellReactor
+    
+    // MARK: - UI Components
+    
+    let dayRoundView = UIView().then {
+        $0.layer.cornerRadius = 16
+    }
+    
+    let dayLabel = UILabel().then {
+        $0.text = "1"
+        $0.textColor = FootprintIOSAsset.Colors.blackD.color
+        $0.font = .systemFont(ofSize: 14)
+        $0.textAlignment = .center
+    }
+    
+    func bind(reactor: Reactor) {
+        dayLabel.text = "\(reactor.currentState.day)"
+    }
+}

--- a/FootprintIOS/FootprintIOS/Sources/View/Home/Cell/MonthCollectionViewCellReactor.swift
+++ b/FootprintIOS/FootprintIOS/Sources/View/Home/Cell/MonthCollectionViewCellReactor.swift
@@ -1,0 +1,24 @@
+//
+//  MonthCollectionViewCellReactor.swift
+//  Footprint-iOSTests
+//
+//  Created by 김영인 on 2022/11/04.
+//  Copyright © 2022 Footprint-iOS. All rights reserved.
+//
+
+import ReactorKit
+
+class MonthCollectionViewCellReactor: Reactor {
+    enum Action { }
+    enum Mutation {}
+    
+    struct State {
+        var day: Int
+    }
+    
+    var initialState: State
+    
+    init(state: State) {
+        self.initialState = state
+    }
+}

--- a/FootprintIOS/FootprintIOS/Sources/View/Home/MonthView.swift
+++ b/FootprintIOS/FootprintIOS/Sources/View/Home/MonthView.swift
@@ -8,8 +8,12 @@
 
 import UIKit
 
+import ReactorKit
+
 class MonthView: BaseView {
     
+    typealias Reactor = HomeReactor
+        
     // MARK: - UI Components
     
     let monthLabel = UILabel().then {
@@ -17,6 +21,12 @@ class MonthView: BaseView {
         $0.font = .systemFont(ofSize: 14, weight: .semibold)
         $0.textColor = FootprintIOSAsset.Colors.blackD.color
         $0.textAlignment = .center
+    }
+    
+    lazy var dayStackView = UIStackView().then {
+        $0.distribution = .equalCentering
+        $0.alignment = .center
+        $0.axis = .horizontal
     }
     
     let collectionView = UIView().then {
@@ -66,11 +76,19 @@ class MonthView: BaseView {
     
     private let bottomButton = FootprintButton(type: .startWalk)
     
-    
     // MARK: - Methods
     
     override func setupProperty() {
         super.setupProperty()
+        
+        for day in ["일", "월", "화", "수", "목", "금", "토"] {
+            let dayLabel = UILabel().then {
+                $0.text = day
+                $0.font = .systemFont(ofSize: 12)
+                $0.textColor = FootprintIOSAsset.Colors.blackD.color
+            }
+            dayStackView.addArrangedSubview(dayLabel)
+        }
         
         [line1View, line2View].forEach {
             $0.backgroundColor = FootprintIOSAsset.Colors.whiteD.color
@@ -80,7 +98,7 @@ class MonthView: BaseView {
     override func setupHierarchy() {
         super.setupHierarchy()
         
-        addSubviews([monthLabel, collectionView, monthStackView, bottomButton])
+        addSubviews([monthLabel, dayStackView, collectionView, monthStackView, bottomButton])
     }
     
     override func setupLayout() {
@@ -91,9 +109,15 @@ class MonthView: BaseView {
             $0.centerX.equalToSuperview()
         }
         
+        dayStackView.snp.makeConstraints {
+            $0.top.equalTo(monthLabel.snp.bottom).offset(15)
+            $0.leading.trailing.equalToSuperview().inset(30)
+            $0.height.equalTo(12)
+        }
+        
         collectionView.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview()
-            $0.top.equalTo(monthLabel.snp.bottom).offset(10)
+            $0.leading.trailing.equalToSuperview().inset(10)
+            $0.top.equalTo(dayStackView.snp.bottom).offset(10)
             $0.bottom.equalTo(monthStackView.snp.top).offset(-10)
         }
         
@@ -114,5 +138,9 @@ class MonthView: BaseView {
             $0.height.equalTo(56)
             $0.bottom.equalToSuperview().inset(24)
         }
+    }
+    
+    func bind(reactor: HomeReactor) {
+        
     }
 }

--- a/FootprintIOS/FootprintIOS/Sources/View/Home/MonthView.swift
+++ b/FootprintIOS/FootprintIOS/Sources/View/Home/MonthView.swift
@@ -10,11 +10,109 @@ import UIKit
 
 class MonthView: BaseView {
     
+    // MARK: - UI Components
+    
+    let monthLabel = UILabel().then {
+        $0.text = "2022년 9월"
+        $0.font = .systemFont(ofSize: 14, weight: .semibold)
+        $0.textColor = FootprintIOSAsset.Colors.blackD.color
+        $0.textAlignment = .center
+    }
+    
+    let collectionView = UIView().then {
+        $0.backgroundColor = .lightGray
+    }
+    
+    let timeLabel = UILabel().then {
+        $0.attributedText = NSMutableAttributedString()
+            .regular(string: "총 시간 \n", fontSize: 12)
+            .bold(string: "135", fontSize: 24)
+            .regular(string: " 시간", fontSize: 12)
+        $0.textColor = FootprintIOSAsset.Colors.blackD.color
+        $0.textAlignment = .center
+        $0.numberOfLines = 0
+    }
+    
+    let distanceLabel = UILabel().then {
+        $0.attributedText = NSMutableAttributedString()
+            .regular(string: "거리 \n", fontSize: 12)
+            .bold(string: "2.1", fontSize: 24)
+            .regular(string: " km", fontSize: 12)
+        $0.textColor = FootprintIOSAsset.Colors.blackD.color
+        $0.textAlignment = .center
+        $0.numberOfLines = 0
+    }
+    
+    let calorieLabel = UILabel().then {
+        $0.attributedText = NSMutableAttributedString()
+            .regular(string: "칼로리 \n", fontSize: 12)
+            .bold(string: "120", fontSize: 24)
+            .regular(string: " kcal", fontSize: 12)
+        $0.textColor = FootprintIOSAsset.Colors.blackD.color
+        $0.textAlignment = .center
+        $0.numberOfLines = 0
+    }
+    
+    let line1View = UIView()
+    let line2View = UIView()
+    
+    lazy var monthStackView = UIStackView().then {
+        $0.addArrangedSubviews(timeLabel, line1View, distanceLabel, line2View, calorieLabel)
+        $0.distribution = .fillProportionally
+        $0.alignment = .center
+        $0.spacing = 10
+        $0.axis = .horizontal
+    }
+    
+    private let bottomButton = FootprintButton(type: .startWalk)
+    
+    
     // MARK: - Methods
     
     override func setupProperty() {
         super.setupProperty()
         
-        self.backgroundColor = .systemYellow
+        [line1View, line2View].forEach {
+            $0.backgroundColor = FootprintIOSAsset.Colors.whiteD.color
+        }
+    }
+    
+    override func setupHierarchy() {
+        super.setupHierarchy()
+        
+        addSubviews([monthLabel, collectionView, monthStackView, bottomButton])
+    }
+    
+    override func setupLayout() {
+        super.setupLayout()
+        
+        monthLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(12)
+            $0.centerX.equalToSuperview()
+        }
+        
+        collectionView.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview()
+            $0.top.equalTo(monthLabel.snp.bottom).offset(10)
+            $0.bottom.equalTo(monthStackView.snp.top).offset(-10)
+        }
+        
+        [line1View, line2View].forEach {
+            $0.snp.makeConstraints {
+                $0.width.equalTo(1)
+                $0.height.equalTo(35)
+            }
+        }
+        
+        monthStackView.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(30)
+            $0.bottom.equalTo(bottomButton.snp.top).offset(-20)
+        }
+        
+        bottomButton.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(24)
+            $0.height.equalTo(56)
+            $0.bottom.equalToSuperview().inset(24)
+        }
     }
 }

--- a/FootprintIOS/FootprintIOS/Sources/View/Home/SectionModel/MonthSectionModel.swift
+++ b/FootprintIOS/FootprintIOS/Sources/View/Home/SectionModel/MonthSectionModel.swift
@@ -1,0 +1,37 @@
+//
+//  MonthSectionModel.swift
+//  Footprint-iOSTests
+//
+//  Created by 김영인 on 2022/11/04.
+//  Copyright © 2022 Footprint-iOS. All rights reserved.
+//
+
+import RxDataSources
+
+typealias MonthSectionModel = SectionModel<MonthSection, MonthItem>
+
+enum MonthSection {
+    case month([MonthItem])
+}
+
+enum MonthItem {
+    case month(MonthCollectionViewCellReactor)
+}
+
+extension MonthSection: SectionModelType {
+    typealias Item = MonthItem
+    
+    var items: [Item] {
+        switch self {
+        case let .month(items):
+            return items
+        }
+    }
+    
+    init(original: MonthSection, items: [MonthItem]) {
+        switch original {
+        case let .month(items):
+            self = .month(items)
+        }
+    }
+}

--- a/FootprintIOS/FootprintIOS/Sources/ViewController/Home/HomeReactor.swift
+++ b/FootprintIOS/FootprintIOS/Sources/ViewController/Home/HomeReactor.swift
@@ -15,6 +15,7 @@ class HomeReactor: Reactor {
     }
     
     enum Action {
+        case refresh
         case scrollHomeContent(x: Int)
         case didEndScroll
         case tapHomeViewTypeButton(HomeViewType)
@@ -26,6 +27,8 @@ class HomeReactor: Reactor {
         case showHomeContent(Int)
         case showHomeView(HomeViewType)
         case showTodayData(TodayDataType)
+        
+        case setMonthSections([MonthSectionModel])
     }
     
     struct State {
@@ -33,6 +36,8 @@ class HomeReactor: Reactor {
         var didEndScroll: Int = 0
         var homeViewType: HomeViewType = .today
         var todayDataType: TodayDataType = .percent
+        
+        var monthSections: [MonthSectionModel] = []
     }
     
     var initialState: State
@@ -43,6 +48,8 @@ class HomeReactor: Reactor {
     
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
+        case .refresh:
+            return .just(.setMonthSections(makeSections()))
         case let .scrollHomeContent(x):
             return .just(.showIndicatorBar(x))
         case .didEndScroll:
@@ -66,8 +73,22 @@ class HomeReactor: Reactor {
             newState.homeViewType = type
         case .showTodayData(let type):
             newState.todayDataType = type
+        case let.setMonthSections(sections):
+            newState.monthSections = sections
         }
         
         return newState
+    }
+}
+
+extension HomeReactor {
+    func makeSections() -> [MonthSectionModel] {
+        let items = [0...31].map { (day) -> MonthItem in
+            return .month(MonthCollectionViewCellReactor(state: .init(day: 0)))
+        }
+        
+        let section = MonthSectionModel.init(model: .month(items), items: items)
+        
+        return [section]
     }
 }

--- a/FootprintIOS/FootprintIOS/Sources/ViewController/Home/HomeReactor.swift
+++ b/FootprintIOS/FootprintIOS/Sources/ViewController/Home/HomeReactor.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2022 Footprint-iOS. All rights reserved.
 //
 
+import UIKit
+
 import ReactorKit
 
 class HomeReactor: Reactor {
@@ -63,12 +65,14 @@ class HomeReactor: Reactor {
     
     func reduce(state: State, mutation: Mutation) -> State {
         var newState = state
+        let width = UIScreen.main.bounds.width
         
         switch mutation {
         case .showIndicatorBar(let x):
             newState.indicatorX = x
         case .showHomeContent(let x):
             newState.didEndScroll = x
+            newState.homeViewType = (currentState.indicatorX < Int(width) / 2) ? .today : .month
         case .showHomeView(let type):
             newState.homeViewType = type
         case .showTodayData(let type):

--- a/FootprintIOS/FootprintIOS/Sources/ViewController/Home/HomeReactor.swift
+++ b/FootprintIOS/FootprintIOS/Sources/ViewController/Home/HomeReactor.swift
@@ -26,7 +26,7 @@ class HomeReactor: Reactor {
     
     enum Mutation {
         case showIndicatorBar(Int)
-        case showHomeContent(Int)
+        case showHomeContent(Int, HomeViewType)
         case showHomeView(HomeViewType)
         case showTodayData(TodayDataType)
         
@@ -55,7 +55,7 @@ class HomeReactor: Reactor {
         case let .scrollHomeContent(x):
             return .just(.showIndicatorBar(x))
         case .didEndScroll:
-            return .just(.showHomeContent(currentState.indicatorX))
+            return showHomeContentMutation()
         case .tapHomeViewTypeButton(let type):
             return .just(.showHomeView(type))
         case .tapTodayDataButton(let type):
@@ -65,14 +65,13 @@ class HomeReactor: Reactor {
     
     func reduce(state: State, mutation: Mutation) -> State {
         var newState = state
-        let width = UIScreen.main.bounds.width
         
         switch mutation {
         case .showIndicatorBar(let x):
             newState.indicatorX = x
-        case .showHomeContent(let x):
+        case .showHomeContent(let x, let type):
             newState.didEndScroll = x
-            newState.homeViewType = (currentState.indicatorX < Int(width) / 2) ? .today : .month
+            newState.homeViewType = type
         case .showHomeView(let type):
             newState.homeViewType = type
         case .showTodayData(let type):
@@ -86,6 +85,14 @@ class HomeReactor: Reactor {
 }
 
 extension HomeReactor {
+    func showHomeContentMutation() -> Observable<Mutation> {
+        let width = UIScreen.main.bounds.width
+        let x = currentState.indicatorX
+        let type: HomeViewType = (x < Int(width) / 2) ? .today : .month
+        
+        return .just(.showHomeContent(x, type))
+    }
+    
     func makeSections() -> [MonthSectionModel] {
         let items = [0...31].map { (day) -> MonthItem in
             return .month(MonthCollectionViewCellReactor(state: .init(day: 0)))

--- a/FootprintIOS/FootprintIOS/Sources/ViewController/Home/HomeViewController.swift
+++ b/FootprintIOS/FootprintIOS/Sources/ViewController/Home/HomeViewController.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 import ReactorKit
+import RxDataSources
 import SnapKit
 
 class HomeViewController: NavigationBarViewController, View {
@@ -16,6 +17,8 @@ class HomeViewController: NavigationBarViewController, View {
     // MARK: - Properties
     
     typealias Reactor = HomeReactor
+    typealias DataSource = RxCollectionViewSectionedReloadDataSource<MonthSectionModel>
+
     let width = UIScreen.main.bounds.width
     var leftInsetConstraint: Constraint?
     

--- a/FootprintIOS/FootprintIOS/Sources/ViewController/Home/HomeViewController.swift
+++ b/FootprintIOS/FootprintIOS/Sources/ViewController/Home/HomeViewController.swift
@@ -54,14 +54,16 @@ class HomeViewController: NavigationBarViewController, View {
     
     private let todayButton = UIButton().then {
         $0.setTitle("오늘", for: .normal)
-        $0.setTitleColor(FootprintIOSAsset.Colors.blueD.color, for: .normal)
+        $0.setTitleColor(FootprintIOSAsset.Colors.blackL.color, for: .normal)
+        $0.setTitleColor(FootprintIOSAsset.Colors.blueD.color, for: .selected)
         $0.titleLabel?.font = .systemFont(ofSize: 14, weight: .semibold)
     }
     
     private let monthButton = UIButton().then {
         $0.setTitle("이번 달", for: .normal)
         $0.setTitleColor(FootprintIOSAsset.Colors.blackL.color, for: .normal)
-        $0.titleLabel?.font = .systemFont(ofSize: 14)
+        $0.setTitleColor(FootprintIOSAsset.Colors.blueD.color, for: .selected)
+        $0.titleLabel?.font = .systemFont(ofSize: 14, weight: .semibold)
     }
     
     private lazy var tabButtonStackView = UIStackView().then {
@@ -81,6 +83,7 @@ class HomeViewController: NavigationBarViewController, View {
     
     private let homeContentScrollView = UIScrollView().then {
         $0.translatesAutoresizingMaskIntoConstraints = false
+        $0.showsHorizontalScrollIndicator = false
     }
     
     private let homeContentView = UIView().then {
@@ -204,8 +207,8 @@ class HomeViewController: NavigationBarViewController, View {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
-        homeContentScrollView.rx.didEndDecelerating
-            .map { .didEndScroll }
+        homeContentScrollView.rx.didEndDragging
+            .map { _ in .didEndScroll }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
@@ -232,6 +235,8 @@ class HomeViewController: NavigationBarViewController, View {
             .withUnretained(self)
             .bind { (this, type) in
                 let homeX = (type == .today) ? 0 : self.width
+                this.todayButton.isSelected = (type == .today) ? true : false
+                this.monthButton.isSelected = (type == .month) ? true : false
                 this.homeContentScrollView.setContentOffset(CGPoint(x: homeX, y: 0), animated: true)
             }
             .disposed(by: disposeBag)
@@ -248,6 +253,7 @@ class HomeViewController: NavigationBarViewController, View {
             .map(\.didEndScroll)
             .distinctUntilChanged()
             .withUnretained(self)
+            .observe(on: MainScheduler.asyncInstance)
             .bind { (this, x) in
                 let homeX = x > (Int(this.width) / 2) ? this.width : 0
                 this.homeContentScrollView.setContentOffset(CGPoint(x: homeX, y: 0), animated: true)

--- a/FootprintIOS/FootprintIOS/Sources/ViewController/Home/HomeViewController.swift
+++ b/FootprintIOS/FootprintIOS/Sources/ViewController/Home/HomeViewController.swift
@@ -235,8 +235,8 @@ class HomeViewController: NavigationBarViewController, View {
             .withUnretained(self)
             .bind { (this, type) in
                 let homeX = (type == .today) ? 0 : self.width
-                this.todayButton.isSelected = (type == .today) ? true : false
-                this.monthButton.isSelected = (type == .month) ? true : false
+                this.todayButton.isSelected = (type == .today)
+                this.monthButton.isSelected = (type == .month)
                 this.homeContentScrollView.setContentOffset(CGPoint(x: homeX, y: 0), animated: true)
             }
             .disposed(by: disposeBag)


### PR DESCRIPTION
## 📍 *Pull requests*

⛳️ **작업한 브랜치**
- feature/#36

📁 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->

홈 이번달 UI 구현하고, 스크롤 이슈 해결했습니다.

## 📢 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

아직 스크롤이 완벽히 자연스럽지 않은데 이 부분은 후순위로 미뤄도 될 것 같습니다.
스크롤 이슈는
` .observe(on: MainScheduler.asyncInstance)` 을 didEndScroll 부분에 추가하여 해결하였습니다.
didEnd에서 호출되는 scroll과 .setContentOffset 부분에서 스크롤이 겹쳐 해당부분 UI가 그려지지 않았고, 
비동기식으로 바꿔서 해당 UI 업데이트가 가능하게 된 거라고 . .? 생각합니다.

캘린더는 아직 구현하지 않았고, UI만 구현했습니다.

## 📸 스크린샷
https://user-images.githubusercontent.com/74968390/200249050-4fbf5ad3-3aab-4bd4-a855-394a579d5e8c.MP4


## 👣 관련 이슈
- Resolved: #36
