### PR TITLE
[Feat/#44] 발자국 쓰기 뷰 이미지 구현

### DIFF
--- a/FootprintIOS/FootprintIOS/Sources/View/Footprint/Cell/ImageCollectionViewCell.swift
+++ b/FootprintIOS/FootprintIOS/Sources/View/Footprint/Cell/ImageCollectionViewCell.swift
@@ -1,0 +1,30 @@
+//
+//  ImageCollectionViewCell.swift
+//  Footprint-iOS
+//
+//  Created by 송영모 on 2022/11/24.
+//  Copyright © 2022 Footprint-iOS. All rights reserved.
+//
+
+import UIKit
+import ReactorKit
+
+class ImageCollectionViewCell: BaseCollectionViewCell, View {
+    typealias Reactor = ImageCollectionViewCellReactor
+    
+    override func setupProperty() {
+        super.setupProperty()
+    }
+    
+    override func setupHierarchy() {
+        super.setupHierarchy()
+    }
+    
+    override func setupLayout() {
+        super.setupLayout()
+    }
+    
+    func bind(reactor: Reactor) {
+        
+    }
+}

--- a/FootprintIOS/FootprintIOS/Sources/View/Footprint/Cell/ImageCollectionViewCell.swift
+++ b/FootprintIOS/FootprintIOS/Sources/View/Footprint/Cell/ImageCollectionViewCell.swift
@@ -12,19 +12,34 @@ import ReactorKit
 class ImageCollectionViewCell: BaseCollectionViewCell, View {
     typealias Reactor = ImageCollectionViewCellReactor
     
+    // MARK: - UI Components
+    
+    let imageView: UIImageView = .init()
+    
+    // MARK: - Setup Methods
+    
     override func setupProperty() {
         super.setupProperty()
+        
+        imageView.cornerRound(radius: 8)
+        imageView.backgroundColor = .red
     }
     
     override func setupHierarchy() {
         super.setupHierarchy()
+        
+        contentView.addSubviews([imageView])
     }
     
     override func setupLayout() {
         super.setupLayout()
+        
+        imageView.snp.makeConstraints {
+            $0.top.leading.trailing.bottom.equalToSuperview()
+        }
     }
     
     func bind(reactor: Reactor) {
-        
+        imageView.image = reactor.currentState.image
     }
 }

--- a/FootprintIOS/FootprintIOS/Sources/View/Footprint/Cell/ImageCollectionViewCellReactor.swift
+++ b/FootprintIOS/FootprintIOS/Sources/View/Footprint/Cell/ImageCollectionViewCellReactor.swift
@@ -6,35 +6,20 @@
 //  Copyright © 2022 Footprint-iOS. All rights reserved.
 //
 
+import UIKit
 import ReactorKit
 
 class ImageCollectionViewCellReactor: Reactor {
     enum Action {}
     enum Mutation {}
-    struct State {}
+    struct State {
+        var image: UIImage
+    }
     
     var initialState: State
     
-    init() {
-        initialState = State()
+    init(image: UIImage) {
+        initialState = State(image: image)
     }
 }
 
-extension ImageCollectionViewCellReactor {
-    func mutate(action: Action) -> Observable<Mutation> {
-        switch action {
-            
-        }
-        return .empty()
-    }
-    
-    func reduce(state: State, mutation: Mutation) -> State {
-        var newState = state
-        
-        switch mutation {
-            
-        }
-        
-        return newState
-    }
-}

--- a/FootprintIOS/FootprintIOS/Sources/View/Footprint/Cell/ImageCollectionViewCellReactor.swift
+++ b/FootprintIOS/FootprintIOS/Sources/View/Footprint/Cell/ImageCollectionViewCellReactor.swift
@@ -1,0 +1,40 @@
+//
+//  ImageCollectionViewCellReactor.swift
+//  Footprint-iOS
+//
+//  Created by 송영모 on 2022/11/24.
+//  Copyright © 2022 Footprint-iOS. All rights reserved.
+//
+
+import ReactorKit
+
+class ImageCollectionViewCellReactor: Reactor {
+    enum Action {}
+    enum Mutation {}
+    struct State {}
+    
+    var initialState: State
+    
+    init() {
+        initialState = State()
+    }
+}
+
+extension ImageCollectionViewCellReactor {
+    func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+            
+        }
+        return .empty()
+    }
+    
+    func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        
+        switch mutation {
+            
+        }
+        
+        return newState
+    }
+}

--- a/FootprintIOS/FootprintIOS/Sources/View/Footprint/ImageSectionModel.swift
+++ b/FootprintIOS/FootprintIOS/Sources/View/Footprint/ImageSectionModel.swift
@@ -1,0 +1,38 @@
+//
+//  ImageSectionModel.swift
+//  Footprint-iOS
+//
+//  Created by 송영모 on 2022/11/24.
+//  Copyright © 2022 Footprint-iOS. All rights reserved.
+//
+
+import RxDataSources
+
+typealias ImageSectionModel = SectionModel<ImageSection, ImageItem>
+
+enum ImageSection {
+    case image([ImageItem])
+}
+
+enum ImageItem {
+    case image(ImageCollectionViewCellReactor)
+}
+
+extension ImageSection: SectionModelType {
+    typealias Item = ImageItem
+    
+    var items: [Item] {
+        switch self {
+        case let .image(items):
+            return items
+        }
+    }
+    
+    init(original: ImageSection, items: [ImageItem]) {
+        switch original {
+        case let .image(items):
+            self = .image(items)
+        }
+    }
+}
+

--- a/FootprintIOS/FootprintIOS/Sources/ViewController/Footprint/FootprintWrite/FootprintWriteReactor.swift
+++ b/FootprintIOS/FootprintIOS/Sources/ViewController/Footprint/FootprintWrite/FootprintWriteReactor.swift
@@ -6,18 +6,26 @@
 //  Copyright © 2022 Footprint-iOS. All rights reserved.
 //
 
+import UIKit
 import ReactorKit
 
 class FootprintWriteReactor: Reactor {
     enum Action {
+        case refresh
         case editText(String)
+        case resetPicker
+        case pickImage(UIImage)
     }
     
     enum Mutation {
+        case setSections([ImageSectionModel])
+        case addImage(UIImage)
         case updateText(String)
     }
     
     struct State {
+        var sections: [ImageSectionModel] = []
+        var images: [UIImage] = []
         var text: String = ""
     }
     
@@ -31,8 +39,14 @@ class FootprintWriteReactor: Reactor {
 extension FootprintWriteReactor {
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
+        case .refresh:
+            return refreshMutation()
+
         case let .editText(text):
             return .just(.updateText(text))
+            
+        case let .pickImage(image):
+            return pickImagesMutation(image)
         }
     }
     
@@ -40,10 +54,30 @@ extension FootprintWriteReactor {
         var newState = state
         
         switch mutation {
+        case let .setSections(sections):
+            newState.sections = sections
+            
         case let .updateText(text):
             newState.text = text
         }
         
         return newState
+    }
+    
+    private func refreshMutation() -> Observable<Mutation> {
+        return .empty()
+    }
+    
+    private func pickImagesMutation(_ image: UIImage) -> Observable<Mutation> {
+        return .just(.set)
+        return .just(.setSections(makeSections(from: images)))
+    }
+    
+    private func makeSections(from images: [UIImage]) -> [ImageSectionModel] {
+        let items: [ImageItem] = images.map({ (image) -> ImageItem in
+            return .image(.init())
+        })
+        let section: ImageSectionModel = .init(model: .image(items), items: items)
+        return [section]
     }
 }

--- a/FootprintIOS/FootprintIOS/Sources/ViewController/Footprint/FootprintWrite/FootprintWriteViewController.swift
+++ b/FootprintIOS/FootprintIOS/Sources/ViewController/Footprint/FootprintWrite/FootprintWriteViewController.swift
@@ -123,8 +123,6 @@ class FootprintWriteViewController: NavigationBarViewController, View {
         collectionView.showsVerticalScrollIndicator = false
         collectionView.isPagingEnabled = true
         
-        addPictureView.isHidden = true
-        
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(notification:)), name: UIResponder.keyboardWillShowNotification , object:nil)
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(notification:)), name: UIResponder.keyboardWillHideNotification , object:nil)
     }
@@ -218,6 +216,13 @@ class FootprintWriteViewController: NavigationBarViewController, View {
             }
             .disposed(by: disposeBag)
         
+        addPictureView.addPictureButton.rx.tap
+            .withUnretained(self)
+            .bind { this, _ in
+                this.goToPickerScreen()
+            }
+            .disposed(by: disposeBag)
+        
         accessoryView.addPictureButton.rx.tap
             .withUnretained(self)
             .bind { this, _ in
@@ -251,10 +256,12 @@ class FootprintWriteViewController: NavigationBarViewController, View {
     
     @objc func keyboardWillShow(notification: NSNotification) {
         textView.inputAccessoryView?.isHidden = false
+        addPictureView.isHidden = true
     }
 
     @objc func keyboardWillHide(notification: NSNotification) {
         textView.inputAccessoryView?.isHidden = true
+        addPictureView.isHidden = false
     }
 }
 

--- a/FootprintIOS/FootprintIOS/Sources/ViewController/Footprint/FootprintWrite/FootprintWriteViewController.swift
+++ b/FootprintIOS/FootprintIOS/Sources/ViewController/Footprint/FootprintWrite/FootprintWriteViewController.swift
@@ -280,16 +280,17 @@ extension FootprintWriteViewController {
 extension FootprintWriteViewController: PHPickerViewControllerDelegate {
     func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
         picker.dismiss(animated: true)
-        reactor?.action.onNext(.resolve)
+        var images: [UIImage] = []
+        
         for result in results {
             let itemProvider = result.itemProvider
             if itemProvider.canLoadObject(ofClass: UIImage.self) {
                 itemProvider.loadObject(ofClass: UIImage.self) { [weak self] (image, error) in
                     DispatchQueue.main.async {
                         if let image = image as? UIImage {
-                            self?.reactor?.action.onNext(.resolving(image))
+                            images.append(image)
                             if result.hashValue == results.last?.hashValue {
-                                self?.reactor?.action.onNext(.resolved)
+                                self?.reactor?.action.onNext(.uploadImage(images))
                             }
                         }
                     }


### PR DESCRIPTION
## 📍 *Pull requests*

⛳️ **작업한 브랜치**
- feat/#44

📁 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->

제가 삽질한 부분은 두가지인데 
### 첫번째 - RxDatasource 바인딩 처리

```swift
        reactor.state.map(\.sections)
            .bind(to: collectionView.rx.items(dataSource: dataSource))
            .disposed(by: disposeBag)
        
        reactor.state.map(\.sections)
            .bind { [weak self] sections in
                self?.showCollectionView(sections: sections)
            }
            .disposed(by: disposeBag)
```
똑같은 state를 multiple하게 바인딩 처리하는 로직입니다. 
구독을 두번하는게 성능상 좋지 않다는 이유보다는, 그냥 한곳에서 처리하고 싶다는 이유가 큽니다 .. !

제가 시도한 것은 3가지 입니다.
첫번째: 바인딩에서 setDataSource와 showCollectionView를 동시에 함 -> setDatasource가 잘 안먹힘
두번째: datasource.collectionView(CollectionView, Event) -> 안됌
세번째: bind(to: collectionView.rx.items(dataSource: dataSource), rx.showCollectionView) -> 바인딩 두개 된다고 해서 Binder을 추가해서 해봤는데 애초에 mutiple이 안됐음 ..

### 두번째 - PHPickerViewControllerDelegate 바인딩 처리 

```swift 
    func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
        picker.dismiss(animated: true)
        reactor?.action.onNext(.resolve)
        for result in results {
            let itemProvider = result.itemProvider
            if itemProvider.canLoadObject(ofClass: UIImage.self) {
                itemProvider.loadObject(ofClass: UIImage.self) { [weak self] (image, error) in
                    DispatchQueue.main.async {
                        if let image = image as? UIImage {
                            self?.reactor?.action.onNext(.resolving(image))
                            if result.hashValue == results.last?.hashValue {
                                self?.reactor?.action.onNext(.resolved)
                            }
                        }
                    }
                }
            }
        }
    }
```
엄청나게 끔직한 로직이 완성 되었는데, 요약하면, resolve -> 리셋느낌쓰, resolving -> 이미지 해석 후 추가, resolved -> 이미지 해석 및 추가 끝
조금 더 간단하게 로직을 구현하는 아이디어를 받습니다 . .
시도해본것은 reactor안에서 이걸 구현하는건데, 그게 그거인 것 같았습니다.

## 📢 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://user-images.githubusercontent.com/77970826/204128938-8ccb2c3f-7035-4258-895d-8f5514630442.gif" width ="250">|

## 👣 관련 이슈
- Resolved: #44
