### PR TITLE
[Feat/#54] 알림창 로직 구현

### DIFF
--- a/FootprintIOS/FootprintIOS/Sources/ViewController/Alert/AlertReactor.swift
+++ b/FootprintIOS/FootprintIOS/Sources/ViewController/Alert/AlertReactor.swift
@@ -11,7 +11,6 @@ import ReactorKit
 class AlertReactor: Reactor {
     enum Action {
         case tapCancelButton
-        case tapAlertButton(AlertType)
     }
 
     enum Mutation {
@@ -31,36 +30,6 @@ class AlertReactor: Reactor {
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case .tapCancelButton:
-            return .just(.updateIsDismiss)
-        case .tapAlertButton(let alertType):
-            switch alertType {
-            case .noGoal, .changeGoal, .badge(_):
-                break
-            case .delete:
-                // 서버 통신
-                break
-            case .save(let i):
-                //
-                break
-            case .cancel(let i):
-                //
-                break
-            case .setBadge:
-                //
-                break
-            case .logout:
-                //
-                break
-            case .withdrawal:
-                //
-                break
-            case .deleteAll(let i):
-                //
-                break
-            case .custom:
-                //
-                break
-            }
             return .just(.updateIsDismiss)
         }
     }

--- a/FootprintIOS/FootprintIOS/Sources/ViewController/Calendar/CalendarReactor.swift
+++ b/FootprintIOS/FootprintIOS/Sources/ViewController/Calendar/CalendarReactor.swift
@@ -12,18 +12,39 @@ import ReactorKit
 
 class CalendarReactor: Reactor {
     enum Action {
-        
+        case delete
     }
     
     enum Mutation {
+        case deleteFootprint
     }
     
     struct State {
+        var isDeleted: Bool = false
     }
     
     var initialState: State
     
     init(state: State) {
         self.initialState = state
+    }
+    
+    func mutate(action: Action) -> Observable<Mutation> {
+        print(action)
+        switch action {
+        case .delete:
+            return .just(.deleteFootprint)
+        }
+    }
+    
+    func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        
+        switch mutation {
+        case .deleteFootprint:
+            newState.isDeleted = true
+        }
+        
+        return newState
     }
 }


### PR DESCRIPTION
alertAction 추가

## 📍 *Pull requests*

⛳️ **작업한 브랜치**
- feature/#54

📁 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->

alertAction 클로저 추가해서 알림창 로직 구현했습니다. . .

## 📢 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

``` Swift
        alertButton.rx.tap
            .withUnretained(self)
            .flatMap { owner, _ in
                let delete: PublishSubject<Bool> = .init()
                
                owner.makeAlert(type: .delete, alertAction: {
                    delete.onNext(true)
                })
                
                return delete
            }
            .map { _ in .delete }
            .bind(to: reactor.action)
            .disposed(by: disposeBag)
```

PublishSubject 생성해서 구현했는데요.
오른쪽버튼 눌렀을 때 해당 subject에 이벤트를 방출합니다.
그리고 reactor의 action에 바인딩해주고, reactor 내부에서 로직 구현해주면 됩니다.

단순히 확인 액션이 아니라 00번째 산책과 같이 넘겨줘야할 값이 있다면, `PublishSubject<Int>`로 생성하면 됩니다 !

취소액션처리는 전부 AlertViewController에서 처리해주고 있습니다.

다른 더 좋은 방법이 있다면 . . 환영입니다 . . ^^

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|

## 👣 관련 이슈
- Resolved: #54 
