### PR TITLE
[Feat/#70] 목표설정시간 알림창 구현

### DIFF
--- a/FootprintIOS/FootprintIOS/Sources/Service/InfoService.swift
+++ b/FootprintIOS/FootprintIOS/Sources/Service/InfoService.swift
@@ -12,6 +12,7 @@ enum InfoEvent {
     case updateBirth(content: String)
     case updateWalk(content: String)
     case updateGoalWalk(content: String)
+    case showGoalWalkAlertView
     
     case getThisMonthGoal(GoalResponseDTO)
     case getNextMonthGoal(GoalResponseDTO)
@@ -28,6 +29,7 @@ protocol InfoServiceType {
     func updateBirth(to birth: String) -> Observable<String>
     func updateWalk(to walk: String) -> Observable<String>
     func updateGoalWalk(to goalWalk: String) -> Observable<String>
+    func showGoalWalkAlertView() -> Observable<Void>
 }
 
 class InfoService: NetworkService, InfoServiceType {
@@ -106,6 +108,11 @@ class InfoService: NetworkService, InfoServiceType {
     func updateWalk(to walk: String) -> Observable<String> {
         event.onNext(.updateWalk(content: walk))
         return .just(walk)
+    }
+    
+    func showGoalWalkAlertView() -> Observable<Void> {
+        event.onNext(.showGoalWalkAlertView)
+        return .just(Void())
     }
     
     func updateGoalWalk(to goalWalk: String) -> Observable<String> {

--- a/FootprintIOS/FootprintIOS/Sources/View/Alert/CustomAlertView.swift
+++ b/FootprintIOS/FootprintIOS/Sources/View/Alert/CustomAlertView.swift
@@ -27,7 +27,7 @@ class CustomAlertView: BaseView {
         $0.textColor = FootprintIOSAsset.Colors.blackM.color
     }
     
-    private lazy var customView = UIView.init()
+    lazy var selectGoalWalkTimeView = SelectGoalWalkTimeView.init()
     
     private let lineView = UIView().then {
         $0.backgroundColor = FootprintIOSAsset.Colors.white3.color
@@ -72,28 +72,25 @@ class CustomAlertView: BaseView {
         
         titleLabel.text = type.title
         rightButton.setTitle(type.buttonTitle, for: .normal)
-        
-        switch customViewType {
-        case .selectGoalWalkTime:
-            customView = SelectGoalWalkTimeView.init()
-        case .none:
-            return
-        }
     }
 
     override func setupHierarchy() {
         super.setupHierarchy()
         
         addSubview(backgroundView)
-        backgroundView.addSubviews([titleLabel, customView, lineView, buttonStackView])
+        backgroundView.addSubviews([titleLabel, lineView, buttonStackView])
+        
+        if customViewType == .selectGoalWalkTime {
+            backgroundView.addSubview(selectGoalWalkTimeView)
+        }
     }
     
     override func setupLayout() {
         super.setupLayout()
         
         backgroundView.snp.makeConstraints {
-            $0.width.equalTo(326)
-            $0.height.equalTo(259)
+            $0.width.equalTo(327)
+            $0.height.equalTo(230)
             $0.center.equalToSuperview()
         }
         
@@ -102,10 +99,12 @@ class CustomAlertView: BaseView {
             $0.centerX.equalTo(backgroundView)
         }
         
-        customView.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(10)
-            $0.leading.trailing.equalTo(backgroundView)
-            $0.height.equalTo(150)
+        if customViewType == .selectGoalWalkTime {
+            selectGoalWalkTimeView.snp.makeConstraints {
+                $0.top.equalTo(titleLabel.snp.bottom).offset(10)
+                $0.leading.trailing.equalTo(backgroundView)
+                $0.height.equalTo(130)
+            }
         }
         
         buttonStackView.snp.makeConstraints {

--- a/FootprintIOS/FootprintIOS/Sources/View/Alert/CustomAlertView.swift
+++ b/FootprintIOS/FootprintIOS/Sources/View/Alert/CustomAlertView.swift
@@ -13,6 +13,7 @@ class CustomAlertView: BaseView {
     // MARK: - Properties
     
     let type: AlertType
+    let customViewType: AlertType.Custom?
 
     // MARK: - UI Components
     
@@ -26,10 +27,7 @@ class CustomAlertView: BaseView {
         $0.textColor = FootprintIOSAsset.Colors.blackM.color
     }
     
-    // FIXME: 나중에 재사용 가능성이 있다면 customView도 enum으로 관리
-    private let customView = UIView().then {
-        $0.backgroundColor = .systemYellow
-    }
+    private lazy var customView = UIView.init()
     
     private let lineView = UIView().then {
         $0.backgroundColor = FootprintIOSAsset.Colors.white3.color
@@ -55,8 +53,9 @@ class CustomAlertView: BaseView {
     
     // MARK: - Initializer
     
-    init(type: AlertType) {
+    init(type: AlertType, customViewType: AlertType.Custom?) {
         self.type = type
+        self.customViewType = customViewType
         
         super.init(frame: .zero)
     }
@@ -73,6 +72,13 @@ class CustomAlertView: BaseView {
         
         titleLabel.text = type.title
         rightButton.setTitle(type.buttonTitle, for: .normal)
+        
+        switch customViewType {
+        case .selectGoalWalkTime:
+            customView = SelectGoalWalkTimeView.init()
+        case .none:
+            return
+        }
     }
 
     override func setupHierarchy() {

--- a/FootprintIOS/FootprintIOS/Sources/View/Alert/CustomView/SelectGoalWalkTimeView.swift
+++ b/FootprintIOS/FootprintIOS/Sources/View/Alert/CustomView/SelectGoalWalkTimeView.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 import RxSwift
+import RxRelay
 
 class SelectGoalWalkTimeView: BaseView {
     
@@ -22,8 +23,8 @@ class SelectGoalWalkTimeView: BaseView {
     private var hours: [String] = []
     private var minutes: [String] = []
     
-    var selectedHour = BehaviorSubject<String>(value: "0시간")
-    var selectedMinute = BehaviorSubject<String>(value: "0분")
+    var selectedHour = BehaviorRelay<String>(value: "0시간")
+    var selectedMinute = BehaviorRelay<String>(value: "10분")
     
     // MARK: - UI Components
     
@@ -53,8 +54,14 @@ class SelectGoalWalkTimeView: BaseView {
         }
     }
     
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        pickerView.selectRow(1, inComponent: 1, animated: true)
+    }
+    
     private func setupPickerView() {
-        for hour in Array(0...23) {
+        for hour in Array(0...4) {
             hours.append("\(hour)시간")
         }
         
@@ -82,30 +89,28 @@ extension SelectGoalWalkTimeView: UIPickerViewDataSource {
 }
 
 extension SelectGoalWalkTimeView: UIPickerViewDelegate {
-    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-        switch component {
-        case Time.hour.rawValue:
-            return hours[row]
-        case Time.minute.rawValue:
-            return minutes[row]
-        default:
-            return ""
-        }
-    }
-    
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        
         switch component {
         case Time.hour.rawValue:
-            selectedHour.onNext(hours[row])
+            selectedHour.accept(hours[row])
         case Time.minute.rawValue:
-            selectedMinute.onNext(minutes[row])
+            selectedMinute.accept(minutes[row])
         default:
             break
+        }
+        
+        if selectedHour.value == hours[0] {
+            pickerView.selectRow(1, inComponent: 1, animated: true)
         }
     }
     
     func pickerView(_ pickerView: UIPickerView, rowHeightForComponent component: Int) -> CGFloat {
         return 40
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, widthForComponent component: Int) -> CGFloat {
+        return 90
     }
     
     func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {

--- a/FootprintIOS/FootprintIOS/Sources/View/Alert/CustomView/SelectGoalWalkTimeView.swift
+++ b/FootprintIOS/FootprintIOS/Sources/View/Alert/CustomView/SelectGoalWalkTimeView.swift
@@ -1,0 +1,123 @@
+//
+//  SelectGoalWalkTimeView.swift
+//  Footprint-iOSTests
+//
+//  Created by 김영인 on 2023/02/05.
+//  Copyright © 2023 Footprint-iOS. All rights reserved.
+//
+
+import UIKit
+
+class SelectGoalWalkTimeView: BaseView {
+    
+    enum Time: Int {
+        case hour
+        case minute
+    }
+    
+    // MARK: - Properties
+    
+    private var hours: [String] = []
+    private var minutes: [String] = []
+    
+    // MARK: - UI Components
+    
+    let pickerView = UIPickerView()
+    
+    // MARK: - Methods
+    
+    override func setupProperty() {
+        super.setupProperty()
+        
+        setupPickerView()
+    }
+    
+    override func setupDelegate() {
+        pickerView.delegate = self
+        pickerView.dataSource = self
+    }
+    
+    override func setupHierarchy() {
+        addSubview(pickerView)
+    }
+    
+    override func setupLayout() {
+        pickerView.snp.makeConstraints() {
+            $0.top.bottom.equalToSuperview()
+            $0.leading.trailing.equalToSuperview().inset(20)
+        }
+    }
+    
+    private func setupPickerView() {
+        for hour in Array(0...23) {
+            hours.append("\(hour)시간")
+        }
+        
+        for minute in Array(0...5) {
+            minutes.append("\(minute * 10)분")
+        }
+    }
+}
+
+extension SelectGoalWalkTimeView: UIPickerViewDataSource {
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        return 2
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        switch component {
+        case Time.hour.rawValue:
+            return hours.count
+        case Time.minute.rawValue:
+            return minutes.count
+        default:
+            return 0
+        }
+    }
+}
+
+extension SelectGoalWalkTimeView: UIPickerViewDelegate {
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        switch component {
+        case Time.hour.rawValue:
+            return hours[row]
+        case Time.minute.rawValue:
+            return minutes[row]
+        default:
+            return ""
+        }
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        switch component {
+        case Time.hour.rawValue:
+            print(hours[row])
+        case Time.minute.rawValue:
+            print(minutes[row])
+        default:
+            break
+        }
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, rowHeightForComponent component: Int) -> CGFloat {
+        return 40
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
+        
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 18)
+        label.textAlignment = .center
+        
+        switch component {
+        case Time.hour.rawValue:
+            label.text = hours[row]
+        case Time.minute.rawValue:
+            label.text = minutes[row]
+        default:
+            break
+        }
+        
+        return label
+    }
+}

--- a/FootprintIOS/FootprintIOS/Sources/View/Alert/CustomView/SelectGoalWalkTimeView.swift
+++ b/FootprintIOS/FootprintIOS/Sources/View/Alert/CustomView/SelectGoalWalkTimeView.swift
@@ -8,6 +8,8 @@
 
 import UIKit
 
+import RxSwift
+
 class SelectGoalWalkTimeView: BaseView {
     
     enum Time: Int {
@@ -19,6 +21,9 @@ class SelectGoalWalkTimeView: BaseView {
     
     private var hours: [String] = []
     private var minutes: [String] = []
+    
+    var selectedHour = BehaviorSubject<String>(value: "0시간")
+    var selectedMinute = BehaviorSubject<String>(value: "0분")
     
     // MARK: - UI Components
     
@@ -91,9 +96,9 @@ extension SelectGoalWalkTimeView: UIPickerViewDelegate {
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
         switch component {
         case Time.hour.rawValue:
-            print(hours[row])
+            selectedHour.onNext(hours[row])
         case Time.minute.rawValue:
-            print(minutes[row])
+            selectedMinute.onNext(minutes[row])
         default:
             break
         }

--- a/FootprintIOS/FootprintIOS/Sources/View/Alert/CustomView/SelectGoalWalkTimeView.swift
+++ b/FootprintIOS/FootprintIOS/Sources/View/Alert/CustomView/SelectGoalWalkTimeView.swift
@@ -103,6 +103,9 @@ extension SelectGoalWalkTimeView: UIPickerViewDelegate {
         if selectedHour.value == hours[0] {
             pickerView.selectRow(1, inComponent: 1, animated: true)
         }
+        if selectedHour.value == hours[4] {
+            pickerView.selectRow(0, inComponent: 1, animated: true)
+        }
     }
     
     func pickerView(_ pickerView: UIPickerView, rowHeightForComponent component: Int) -> CGFloat {

--- a/FootprintIOS/FootprintIOS/Sources/View/UserInfo/Goal/GoalView.swift
+++ b/FootprintIOS/FootprintIOS/Sources/View/UserInfo/Goal/GoalView.swift
@@ -10,10 +10,6 @@ import UIKit
 
 class GoalView: BaseView {
     
-    // MARK: - Properties
-    
-    var walkTimes: [Int] = [15, 30, 60, 90, 0]
-    
     // MARK: - UI Components
     
     lazy var dayButtons: [UIButton] = []
@@ -120,11 +116,25 @@ class GoalView: BaseView {
     func getWalkIndex(type: UserInfoSelectBarType) -> Int {
         switch type {
         case .goalTime:
-            for (index, walkType) in InfoTexts.goalWalkTexts.enumerated() {
-                if walkType == goalWalkSelectView.selectLabel.text {
-                    return walkTimes[safe: index] ?? 0
-                }
+            let time = goalWalkSelectView.selectLabel.text ?? ""
+            var goalTime: Int
+            
+            if !time.contains("시간") {
+                goalTime = time.split(separator: "분").map { Int($0) ?? 0 }.first ?? 0
+            } else if !time.contains("분") {
+                goalTime = (time.split(separator: "시간").map { Int($0) ?? 0 }.first ?? 0) * 60
+            } else {
+                let hourMinute = time.split(separator: " ")
+                let hour = (hourMinute[0].split(separator: "시간").map { Int($0) ?? 0 }.first ?? 0) * 60
+                let minute = hourMinute[1].split(separator: "분").map { Int($0) ?? 0 }.first ?? 0
+                goalTime = hour + minute
             }
+            
+            if time == "0분" {
+                goalTime = 10
+            }
+            
+            return goalTime
         case .time:
             for (index, walkType) in InfoTexts.walkTexts.enumerated() {
                 if walkType == walkSelectView.selectLabel.text {

--- a/FootprintIOS/FootprintIOS/Sources/ViewController/Alert/AlertViewController.swift
+++ b/FootprintIOS/FootprintIOS/Sources/ViewController/Alert/AlertViewController.swift
@@ -205,7 +205,12 @@ class AlertViewController: NavigationBarViewController, View {
                 customAlertView.selectGoalWalkTimeView.selectedHour,
                 customAlertView.selectGoalWalkTimeView.selectedMinute
             ).bind { [weak self] (hour, minute) in
-                self?.selectedTime = "\(hour) \(minute)"
+                let time = hour.contains("0") ? "\(minute)" :
+                (minute == "0분") ? "\(hour)" : "\(hour) \(minute)"
+                
+                if time == "0분" {
+                    self?.selectedTime = "10분"
+                }
             }
             .disposed(by: disposeBag)
         }

--- a/FootprintIOS/FootprintIOS/Sources/ViewController/Alert/AlertViewController.swift
+++ b/FootprintIOS/FootprintIOS/Sources/ViewController/Alert/AlertViewController.swift
@@ -208,6 +208,7 @@ class AlertViewController: NavigationBarViewController, View {
                 let time = hour.contains("0") ? "\(minute)" :
                 (minute == "0분") ? "\(hour)" : "\(hour) \(minute)"
                 
+                self?.selectedTime = time
                 if time == "0분" {
                     self?.selectedTime = "10분"
                 }

--- a/FootprintIOS/FootprintIOS/Sources/ViewController/Alert/AlertViewController.swift
+++ b/FootprintIOS/FootprintIOS/Sources/ViewController/Alert/AlertViewController.swift
@@ -22,7 +22,11 @@ enum AlertType {
     case withdrawal
     case deleteAll(Int)
     case badge(String)
-    case custom
+    case custom(value: Custom)
+    
+    enum Custom {
+        case selectGoalWalkTime
+    }
     
     var title: String {
         switch self {
@@ -46,7 +50,7 @@ enum AlertType {
             return "\(i)번째 산책'을 삭제하시겠어요?"
         case let .badge(badgeName):
             return "\(badgeName)\n뱃지를 획득했어요!"
-        case .custom:
+        case .custom(value: .selectGoalWalkTime):
             return "목표산책시간 직접설정"
         }
     }
@@ -89,6 +93,7 @@ class AlertViewController: NavigationBarViewController, View {
     // MARK: - Properties
     
     private let type: AlertType
+    private let customViewType: AlertType.Custom?
     typealias Reactor = AlertReactor
     var alertAction: (() -> Void)?
     
@@ -97,16 +102,17 @@ class AlertViewController: NavigationBarViewController, View {
     private lazy var oneButtonAlertView = OneButtonAlertView.init(type: self.type)
     private lazy var twoButtonAlertView = TwoButtonAlertView.init(type: self.type)
     private lazy var badgeAlertView = BadgeAlertView.init(type: self.type)
-    private lazy var customAlertView = CustomAlertView.init(type: self.type)
+    private lazy var customAlertView = CustomAlertView.init(type: self.type, customViewType: self.customViewType)
     
     // MARK: - Initializer
     
-    init(type: AlertType, reator: Reactor) {
+    init(type: AlertType, customViewType: AlertType.Custom? = nil, reactor: Reactor) {
         self.type = type
+        self.customViewType = customViewType
         
         super.init(nibName: nil, bundle: nil)
         
-        self.reactor = reator
+        self.reactor = reactor
     }
     
     @available(*, unavailable)
@@ -209,8 +215,8 @@ class AlertViewController: NavigationBarViewController, View {
 }
 
 extension UIViewController {
-    func makeAlert(type: AlertType, alertAction: (() -> Void)? = nil) {
-        let alertVC = AlertViewController(type: type, reator: .init())
+    func makeAlert(type: AlertType, customViewType: AlertType.Custom? = nil, alertAction: (() -> Void)? = nil) {
+        let alertVC = AlertViewController(type: type, customViewType: customViewType, reactor: .init())
         alertVC.modalTransitionStyle = .crossDissolve
         alertVC.modalPresentationStyle = .overCurrentContext
         alertVC.alertAction = alertAction

--- a/FootprintIOS/FootprintIOS/Sources/ViewController/Alert/AlertViewController.swift
+++ b/FootprintIOS/FootprintIOS/Sources/ViewController/Alert/AlertViewController.swift
@@ -205,6 +205,11 @@ class AlertViewController: NavigationBarViewController, View {
                 customAlertView.selectGoalWalkTimeView.selectedHour,
                 customAlertView.selectGoalWalkTimeView.selectedMinute
             ).bind { [weak self] (hour, minute) in
+                if hour == "4시간" {
+                    self?.selectedTime = "4시간"
+                    return
+                }
+                
                 let time = hour.contains("0") ? "\(minute)" :
                 (minute == "0분") ? "\(hour)" : "\(hour) \(minute)"
                 

--- a/FootprintIOS/FootprintIOS/Sources/ViewController/UserInfo/Goal/GoalBottomSheet/GoalWalkBottomSheet/GoalWalkBottomSheetReactor.swift
+++ b/FootprintIOS/FootprintIOS/Sources/ViewController/UserInfo/Goal/GoalBottomSheet/GoalWalkBottomSheet/GoalWalkBottomSheetReactor.swift
@@ -15,12 +15,14 @@ class GoalWalkBottomSheetReactor: Reactor {
     
     enum Mutation {
         case updateGoalWalkInfo(String)
+        case selectGoalWalkTime
         case dismiss
     }
     
     struct State {
         var goalWalk: String?
         var goalWalkNum: Int?
+        var showGoalWalkTimeAlertView: Bool = false
         var dismiss: Bool = true
     }
     
@@ -34,8 +36,8 @@ class GoalWalkBottomSheetReactor: Reactor {
     
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
-        case .tapGoalWalkTime(let goalWalk):
-            return service.updateGoalWalk(to: goalWalk).map { _ in .dismiss }
+        case .tapGoalWalkTime(let goalWalkTime):
+            return goalWalkTimeMutation(goalWalkTime)
         }
     }
     
@@ -45,10 +47,23 @@ class GoalWalkBottomSheetReactor: Reactor {
         switch mutation {
         case .updateGoalWalkInfo(let goalWalk):
             newState.goalWalk = goalWalk
+        case .selectGoalWalkTime:
+            newState.showGoalWalkTimeAlertView = true
         case .dismiss:
             newState.dismiss = true
+            newState.showGoalWalkTimeAlertView = false
         }
         
         return newState
+    }
+}
+
+extension GoalWalkBottomSheetReactor {
+    private func goalWalkTimeMutation(_ goalWalkTime: String) -> Observable<Mutation> {
+        if goalWalkTime == "직접 설정" {
+            return .just(.selectGoalWalkTime)
+        } else {
+            return service.updateGoalWalk(to: goalWalkTime).map { _ in .dismiss }
+        }
     }
 }

--- a/FootprintIOS/FootprintIOS/Sources/ViewController/UserInfo/Goal/GoalBottomSheet/GoalWalkBottomSheet/GoalWalkBottomSheetViewController.swift
+++ b/FootprintIOS/FootprintIOS/Sources/ViewController/UserInfo/Goal/GoalBottomSheet/GoalWalkBottomSheet/GoalWalkBottomSheetViewController.swift
@@ -94,17 +94,28 @@ final class GoalWalkBottomSheetViewController: BottomSheetViewController, View {
     func bind(reactor: GoalWalkBottomSheetReactor) {
         setGoalWalkLabels()
         
-        for goalWalk in 0..<5 {
+        for goalWalk in texts.indices {
             goalWalkLabels[goalWalk].rx.tapGesture()
                 .when(.recognized)
                 .withUnretained(self)
                 .map { owner, _ -> String in
-                    return owner.texts[goalWalk] ?? "0"
+                    return owner.texts[goalWalk]
                 }
                 .map { .tapGoalWalkTime($0) }
                 .bind(to: reactor.action)
                 .disposed(by: disposeBag)
         }
+        
+        reactor.state
+            .map(\.showGoalWalkTimeAlertView)
+            .filter { $0 }
+            .withUnretained(self)
+            .bind { owner, _ in
+                owner.dismiss(animated: true) {
+                    reactor.service.showGoalWalkAlertView()
+                }
+            }
+            .disposed(by: disposeBag)
         
         reactor.state
             .map(\.dismiss)

--- a/FootprintIOS/FootprintIOS/Sources/ViewController/UserInfo/Goal/GoalEdit/NextMonth/GoalEditNextMonthViewController.swift
+++ b/FootprintIOS/FootprintIOS/Sources/ViewController/UserInfo/Goal/GoalEdit/NextMonth/GoalEditNextMonthViewController.swift
@@ -110,16 +110,6 @@ final class GoalEditNextMonthViewController: NavigationBarViewController, View {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
-        goalView.walkSelectView.rx.tapGesture()
-            .when(.recognized)
-            .withUnretained(self)
-            .bind { owner, _ in
-                let reactor = reactor.reactorForWalk()
-                let walkBottomSheet = WalkBottomSheetViewController(reactor: reactor)
-                owner.present(walkBottomSheet, animated: true)
-            }
-            .disposed(by: disposeBag)
-        
         goalView.goalWalkSelectView.rx.tapGesture()
             .when(.recognized)
             .withUnretained(self)
@@ -127,6 +117,16 @@ final class GoalEditNextMonthViewController: NavigationBarViewController, View {
                 let reactor = reactor.reactorForGoalWalk()
                 let goalWalkBottomSheet = GoalWalkBottomSheetViewController(reactor: reactor)
                 owner.present(goalWalkBottomSheet, animated: true)
+            }
+            .disposed(by: disposeBag)
+        
+        goalView.walkSelectView.rx.tapGesture()
+            .when(.recognized)
+            .withUnretained(self)
+            .bind { owner, _ in
+                let reactor = reactor.reactorForWalk()
+                let walkBottomSheet = WalkBottomSheetViewController(reactor: reactor)
+                owner.present(walkBottomSheet, animated: true)
             }
             .disposed(by: disposeBag)
         

--- a/FootprintIOS/FootprintIOS/Sources/ViewController/UserInfo/Goal/GoalReactor.swift
+++ b/FootprintIOS/FootprintIOS/Sources/ViewController/UserInfo/Goal/GoalReactor.swift
@@ -18,6 +18,7 @@ class GoalReactor: Reactor {
         case updateDayButton(Int)
         case updateWalk(String)
         case updateGoalWalk(String)
+        case showGoalWalkAlertView
     }
     
     struct State {
@@ -25,6 +26,7 @@ class GoalReactor: Reactor {
         var walk: String?
         var goalWalk: String?
         var isEnabledDoneButton: [Bool] = [false, false, false]
+        var isPresentGoalWalkSelectView: Bool = false
     }
     
     var initialState: State
@@ -53,6 +55,8 @@ class GoalReactor: Reactor {
                 return .just(.updateWalk(walk))
             case .updateGoalWalk(content: let goalWalk):
                 return .just(.updateGoalWalk(goalWalk))
+            case .showGoalWalkAlertView:
+                return .just(.showGoalWalkAlertView)
             default:
                 return .never()
             }
@@ -74,6 +78,9 @@ class GoalReactor: Reactor {
         case .updateGoalWalk(let goalWalk):
             newState.goalWalk = goalWalk
             newState.isEnabledDoneButton[2] = true
+            newState.isPresentGoalWalkSelectView = false
+        case .showGoalWalkAlertView:
+            newState.isPresentGoalWalkSelectView = true
         }
         
         return newState

--- a/FootprintIOS/FootprintIOS/Sources/ViewController/UserInfo/Goal/GoalReactor.swift
+++ b/FootprintIOS/FootprintIOS/Sources/ViewController/UserInfo/Goal/GoalReactor.swift
@@ -72,15 +72,18 @@ class GoalReactor: Reactor {
         case .updateDayButton(let day):
             newState.isSelectedButtons[day] = !newState.isSelectedButtons[day]
             newState.isEnabledDoneButton[0] = newState.isSelectedButtons.filter { $0 }.count > 0
+            newState.isPresentGoalWalkSelectView = false
         case .updateWalk(let walk):
             newState.walk = walk
             newState.isEnabledDoneButton[1] = true
+            newState.isPresentGoalWalkSelectView = false
         case .updateGoalWalk(let goalWalk):
             newState.goalWalk = goalWalk
             newState.isEnabledDoneButton[2] = true
             newState.isPresentGoalWalkSelectView = false
         case .showGoalWalkAlertView:
             newState.isPresentGoalWalkSelectView = true
+            newState.isEnabledDoneButton[2] = true
         }
         
         return newState

--- a/FootprintIOS/FootprintIOS/Sources/ViewController/UserInfo/Goal/GoalViewController.swift
+++ b/FootprintIOS/FootprintIOS/Sources/ViewController/UserInfo/Goal/GoalViewController.swift
@@ -139,9 +139,11 @@ class GoalViewController: BaseViewController, View {
         bottomButton.rx.tap
             .withUnretained(self)
             .map { owner, _ -> GoalRequestDTO in
-                let info = GoalRequestDTO(dayIdx: reactor.currentState.isSelectedButtons.enumerated().filter { $0.1 }.map { $0.0 + 1 },
-                                       walkGoalTime: owner.goalView.getWalkIndex(type: .goalTime),
-                                       walkTimeSlot: owner.goalView.getWalkIndex(type: .time))
+                let info = GoalRequestDTO(
+                    dayIdx: reactor.currentState.isSelectedButtons
+                        .enumerated().filter { $0.1 }.map { $0.0 + 1 },
+                    walkGoalTime: owner.goalView.getWalkIndex(type: .goalTime),
+                    walkTimeSlot: owner.goalView.getWalkIndex(type: .time))
                 
                 return info
             }
@@ -202,15 +204,17 @@ class GoalViewController: BaseViewController, View {
             .flatMap { owner, _ in
                 let selectGoalWalkTime: PublishSubject<String> = .init()
                 
-                owner.makeAlert(type: .custom(value: .selectGoalWalkTime), customViewType: .selectGoalWalkTime, alertAction: {
-                    
+                owner.makeAlert(type: .custom(value: .selectGoalWalkTime),
+                                customViewType: .selectGoalWalkTime,
+                                selectTimeAction: { time in
+                    selectGoalWalkTime.onNext(time)
                 })
                 
                 return selectGoalWalkTime
             }
             .withUnretained(self)
             .bind { (owner, goalWalkTime) in
-                print("!! alert !!")
+                owner.goalView.goalWalkSelectView.update(text: goalWalkTime)
             }
             .disposed(by: disposeBag)
         

--- a/FootprintIOS/FootprintIOS/Sources/ViewController/UserInfo/Goal/GoalViewController.swift
+++ b/FootprintIOS/FootprintIOS/Sources/ViewController/UserInfo/Goal/GoalViewController.swift
@@ -149,16 +149,6 @@ class GoalViewController: BaseViewController, View {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
-        goalView.walkSelectView.rx.tapGesture()
-            .when(.recognized)
-            .withUnretained(self)
-            .bind { owner, _ in
-                let reactor = reactor.reactorForWalk()
-                let walkBottomSheet = WalkBottomSheetViewController(reactor: reactor)
-                owner.present(walkBottomSheet, animated: true)
-            }
-            .disposed(by: disposeBag)
-        
         goalView.goalWalkSelectView.rx.tapGesture()
             .when(.recognized)
             .withUnretained(self)
@@ -166,6 +156,16 @@ class GoalViewController: BaseViewController, View {
                 let reactor = reactor.reactorForGoalWalk()
                 let goalWalkBottomSheet = GoalWalkBottomSheetViewController(reactor: reactor)
                 owner.present(goalWalkBottomSheet, animated: true)
+            }
+            .disposed(by: disposeBag)
+        
+        goalView.walkSelectView.rx.tapGesture()
+            .when(.recognized)
+            .withUnretained(self)
+            .bind { owner, _ in
+                let reactor = reactor.reactorForWalk()
+                let walkBottomSheet = WalkBottomSheetViewController(reactor: reactor)
+                owner.present(walkBottomSheet, animated: true)
             }
             .disposed(by: disposeBag)
         
@@ -180,6 +180,14 @@ class GoalViewController: BaseViewController, View {
             .disposed(by: disposeBag)
         
         reactor.state
+            .compactMap(\.walk)
+            .withUnretained(self)
+            .bind { owner, walk in
+                owner.goalView.walkSelectView.update(text: walk)
+            }
+            .disposed(by: disposeBag)
+        
+        reactor.state
             .compactMap(\.goalWalk)
             .withUnretained(self)
             .bind { owner, goalWalk in
@@ -188,10 +196,21 @@ class GoalViewController: BaseViewController, View {
             .disposed(by: disposeBag)
         
         reactor.state
-            .compactMap(\.walk)
+            .map(\.isPresentGoalWalkSelectView)
+            .filter { $0 }
             .withUnretained(self)
-            .bind { owner, walk in
-                owner.goalView.walkSelectView.update(text: walk)
+            .flatMap { owner, _ in
+                let selectGoalWalkTime: PublishSubject<String> = .init()
+                
+                owner.makeAlert(type: .custom(value: .selectGoalWalkTime), customViewType: .selectGoalWalkTime, alertAction: {
+                    
+                })
+                
+                return selectGoalWalkTime
+            }
+            .withUnretained(self)
+            .bind { (owner, goalWalkTime) in
+                print("!! alert !!")
             }
             .disposed(by: disposeBag)
         


### PR DESCRIPTION
## 📍 *Pull requests*

⛳️ **작업한 브랜치**
- feature/#70

📁 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->

목표설정시간 알림창 구현했습니다.
굉장히 끔찍한 로직인데 .. 참을인 열번만 부탁드립니다 ..

## 📢 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

###  알림창 구현 방식

선택된 시간과 분을 BehaviorRelay로 선언하였고, 
alertVC에서 selectedHour와 selectedMinute을 combineLatest을 통해 방출하여 "00시간 00분" 형태의 selectedTime 프로퍼티에 저장합니다.
그리고 alertView의 확인버튼이 눌릴 시, 해당 "00시간 00분"을 목표시간설정의 뷰에 보이도록 구현했습니다.

**고민사항 . .**
rxitems를 쓰는 방식으로 구현하려 했으나 결국 실패했습니다 . .
지금 방식 말고 더 나은 방식이 생각나신다면 조언 부탁드려요 . . ^!^

---
### 바텀시트 -> 알림창 뜨게하는 구현방식

infoService에 showAlertView를 추가했습니다.
바텀시트에서 직접설정을 누를 시 해당 바텀시트가 dismiss되면서 completion으로 이 infoService의 showAlertView를 호출합니다.
그럼 goalVC에서 transform으로 showAlertView를 받게 되고, makeAlert()함수를 통해 해당 알림창을 노출합니다 . .

바텀시트의 dismiss 부분 코드
``` Swift
        reactor.state
            .map(\.showGoalWalkTimeAlertView)
            .filter { $0 }
            .withUnretained(self)
            .bind { owner, _ in
                owner.dismiss(animated: true) {
                    reactor.service.showGoalWalkAlertView()
                }
            }
            .disposed(by: disposeBag)
```

---
### 시간 범위
최소 10분 ~ 최대 4시간이기 때문에 
0시간 선택시 10분으로 자동 스크롤 / 4시간 선택시 0분으로 자동스크롤로 구현해두었습니다.
0시간 선택시 무조건 10분 / 4시간 선택시 무조건 4시간 노출되도록 했습니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://user-images.githubusercontent.com/74968390/217807144-86267e89-1936-4931-bf8f-44c4ae2af4de.gif" width ="250">|


## 👣 관련 이슈
- Resolved: #70
